### PR TITLE
Feature/binhnt add sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ docker compose logs db-migrate  # Migration logs
 - **Health Checks**:
   - Frontend: http://localhost:8000/
   - Backend: http://localhost:8080/health
-- **Database**: MySQL external port 3307
+- **Database**: MySQL external port 33017
 
 ### 2. Test load distribution
 
@@ -124,7 +124,7 @@ make test-stress
 
 - **Frontend (via Frontend LB)**: `http://localhost:8000/`
 - **Backend API (via API Gateway)**: `http://localhost:8080/health`
-- **Database**: `mysql://localhost:3307` (MySQL external port)
+- **Database**: `mysql://localhost:33017` (MySQL external port)
 - **Internal Network**:
   - Backend instances: `http://backend-1:3000/health`, `http://backend-2:3000/health`
   - Frontend instances: `http://frontend-1:3000/`, `http://frontend-2:3000/`
@@ -198,7 +198,7 @@ upstream backend_servers {
                                                      ┌─────────────────┐
                                                      │     mysql       │
                                                      │   Port: 3306    │
-                                                     │ (External: 3307)│
+                                                     │ (External: 33017)│
                                                      └─────────────────┘
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,19 @@
 services:
   # Database
-  mysql:
+  mysql-master:
     image: mysql:8.0
-    container_name: demo_mysql
+    container_name: mysql-master
     environment:
       MYSQL_ROOT_PASSWORD: rootpassword
       MYSQL_DATABASE: demo_db
       MYSQL_USER: demo_user
       MYSQL_PASSWORD: demo_password
-    volumes:
-      - mysql_data:/var/lib/mysql
-      - ./backend/init.sql:/docker-entrypoint-initdb.d
     ports:
-      - "3307:3306"
+      - "33017:3306"
+    volumes:
+      - master_data:/var/lib/mysql
+      - ./mysql/master:/etc/mysql/conf.d
+      - ./backend/init.sql:/docker-entrypoint-initdb.d
     networks:
       - demo_network
     healthcheck:
@@ -22,28 +23,17 @@ services:
       interval: 30s
       start_period: 30s
     restart: unless-stopped
-
-  mysql-master:
-    image: mysql:8.0
-    container_name: mysql-master
-    environment:
-      MYSQL_ROOT_PASSWORD: rootpass
-      MYSQL_DATABASE: demo_db
-    ports:
-      - "3308:3306"
-    volumes:
-      - mysql_data:/var/lib/mysql
-      - ./mysql/master:/etc/mysql/conf.d
   mysql-slave:
     image: mysql:8.0
     container_name: mysql-slave
     environment:
       MYSQL_ROOT_PASSWORD: rootpass
-      MYSQL_DATABASE: demo_db
+      MYSQL_DATABASE: demo_db_master
+    command: --default-authentication-plugin=mysql_native_password
     ports:
-      - "3309:3306"
+      - "33019:3306"
     volumes:
-      - mysql_data:/var/lib/mysql
+      - slave_data:/var/lib/mysql
       - ./mysql/slave:/etc/mysql/conf.d
     depends_on:
       - mysql-master
@@ -54,9 +44,9 @@ services:
       dockerfile: Dockerfile
     container_name: demo_db_migrate
     environment:
-      - DATABASE_URL=mysql://demo_user:demo_password@mysql:3306/demo_db
+      - DATABASE_URL=mysql://demo_user:demo_password@mysql-master:3306/demo_db
     depends_on:
-      mysql:
+      mysql-master:
         condition: service_healthy
     networks:
       - demo_network
@@ -70,13 +60,13 @@ services:
       dockerfile: Dockerfile
     container_name: demo_backend_1
     environment:
-      - DATABASE_URL=mysql://demo_user:demo_password@mysql:3306/demo_db
+      - DATABASE_URL=mysql://demo_user:demo_password@mysql-master:3306/demo_db
       - JWT_SECRET=MKmQy9eujOrThzuaOvkP55Oslv8UqSKOyo6J2xIW9nYjFHu56BmkfbQyANXwEv96VWP65UBbEooCGy4J4I0ZYQ==
       - JWT_EXPIRES_IN=7d
       - PORT=3000
       - NODE_ENV=production
     depends_on:
-      mysql:
+      mysql-master:
         condition: service_healthy
       db-migrate:
         condition: service_completed_successfully
@@ -97,13 +87,13 @@ services:
       dockerfile: Dockerfile
     container_name: demo_backend_2
     environment:
-      - DATABASE_URL=mysql://demo_user:demo_password@mysql:3306/demo_db
+      - DATABASE_URL=mysql://demo_user:demo_password@mysql-master:3306/demo_db
       - JWT_SECRET=MKmQy9eujOrThzuaOvkP55Oslv8UqSKOyo6J2xIW9nYjFHu56BmkfbQyANXwEv96VWP65UBbEooCGy4J4I0ZYQ==
       - JWT_EXPIRES_IN=7d
       - PORT=3000
       - NODE_ENV=production
     depends_on:
-      mysql:
+      mysql-master:
         condition: service_healthy
       db-migrate:
         condition: service_completed_successfully
@@ -232,8 +222,6 @@ services:
       - monitoring
 
 volumes:
-  mysql_data:
-    driver: local
   master_data:
     driver: local
   slave_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,30 @@ services:
       start_period: 30s
     restart: unless-stopped
 
+  mysql-master:
+    image: mysql:8.0
+    container_name: mysql-master
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_DATABASE: demo_db
+    ports:
+      - "3308:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+      - ./mysql/master:/etc/mysql/conf.d
+  mysql-slave:
+    image: mysql:8.0
+    container_name: mysql-slave
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_DATABASE: demo_db
+    ports:
+      - "3309:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+      - ./mysql/slave:/etc/mysql/conf.d
+    depends_on:
+      - mysql-master
   # Database Migration Service
   db-migrate:
     build:
@@ -209,6 +233,10 @@ services:
 
 volumes:
   mysql_data:
+    driver: local
+  master_data:
+    driver: local
+  slave_data:
     driver: local
 
 networks:

--- a/docker-compose.yml.backup
+++ b/docker-compose.yml.backup
@@ -12,7 +12,7 @@ services:
       - mysql_data:/var/lib/mysql
       - ./backend/init.sql:/docker-entrypoint-initdb.d
     ports:
-      - "3307:3306"
+      - "33017:3306"
     networks:
       - demo_network
     healthcheck:

--- a/mysql/master/master.cnf
+++ b/mysql/master/master.cnf
@@ -2,3 +2,4 @@
 server-id=1
 log-bin=mysql-bin
 binlog_do_db=demo_db
+default-authentication-plugin=mysql_native_password

--- a/mysql/master/master.cnf
+++ b/mysql/master/master.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+server-id=1
+log-bin=mysql-bin
+binlog_do_db=demo_db

--- a/mysql/slave/slave.cnf
+++ b/mysql/slave/slave.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+server-id=2
+relay-log=relay-log-bin

--- a/mysql/slave/slave.cnf
+++ b/mysql/slave/slave.cnf
@@ -1,3 +1,4 @@
 [mysqld]
 server-id=2
 relay-log=relay-log-bin
+default-authentication-plugin=mysql_native_password


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end MySQL master–slave replication management via Makefile commands (setup master/slave, export/import data, reset replication).

* **Chores**
  * Docker environment now runs separate MySQL master and slave services with dedicated volumes; dependent services point to the master.
  * Updated external MySQL port to 33017; Nginx exporter port unchanged.
  * Introduced replication-ready MySQL configs (binary/relay logs).

* **Documentation**
  * Updated README to reflect new MySQL port and master–slave topology, including health checks and DSN examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->